### PR TITLE
Conditional API endpoint

### DIFF
--- a/frontend/README.adoc
+++ b/frontend/README.adoc
@@ -11,6 +11,15 @@ rustup target add wasm32-unknown-unknown
 dx serve --hot-reload
 ```
 
+## Release
+
+To build a release version, you can run
+```
+LAERNING_TOOL_API="https://saas.laerning-tool.com" cargo build --release
+```
+
+The environment variable can be configured with whatever API you would like to use.
+
 ## Dependency install
 
 ```

--- a/frontend/src/layout/mod.rs
+++ b/frontend/src/layout/mod.rs
@@ -4,7 +4,7 @@ use dioxus_router::prelude::*;
 
 use crate::components::question_component::Question;
 use crate::components::Button;
-use crate::Routes;
+use crate::{Routes, BASE_API};
 
 pub fn AppLayout(cx: Scope) -> Element {
     render! {
@@ -67,9 +67,11 @@ pub fn Footer(cx: Scope) -> Element {
 
 pub fn Quiz(cx: Scope) -> Element {
     let mut count = use_state(cx, || 0);
+    let url = BASE_API;
     render! {
         div {
             "class": "flex flex-col items-center space-y-4",
+            "The base url is {url}"
             Question {
                 "High-Five counter: {count}"
             }

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -14,6 +14,11 @@ use serde::{Deserialize, Serialize};
 mod components;
 mod layout;
 
+#[cfg(debug_assertions)]
+const BASE_API: String = "http://localhost:3000/";
+#[cfg(not(debug_assertions))]
+const BASE_API: String = "/api";
+
 #[derive(Clone, Routable, PartialEq, Eq, Serialize, Deserialize, Debug)]
 enum Routes {
     #[layout(AppLayout)]

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -18,7 +18,7 @@ mod layout;
 #[cfg(debug_assertions)]
 const BASE_API: &str = "http://localhost:3000/";
 #[cfg(not(debug_assertions))]
-const BASE_API: &str = "/api";
+const BASE_API: &str = env!("LAERNING_TOOL_API");
 
 #[derive(Clone, Routable, PartialEq, Eq, Serialize, Deserialize, Debug)]
 enum Routes {

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -1,6 +1,7 @@
 // #![feature(unboxed_closures)]
 #![allow(non_snake_case)]
 
+use std::string::ToString;
 // import the prelude to get access to the `rsx!` macro and the `Scope` and `Element` types
 use crate::components::question_component::Question;
 use crate::components::Button;
@@ -15,9 +16,9 @@ mod components;
 mod layout;
 
 #[cfg(debug_assertions)]
-const BASE_API: String = "http://localhost:3000/";
+const BASE_API: &str = "http://localhost:3000/";
 #[cfg(not(debug_assertions))]
-const BASE_API: String = "/api";
+const BASE_API: &str = "/api";
 
 #[derive(Clone, Routable, PartialEq, Eq, Serialize, Deserialize, Debug)]
 enum Routes {


### PR DESCRIPTION
Add conditional API endpoint for testing the frontend.
When building in debug mode, the API address will point to the default `cargo run` of the engine, `http://localhost:3000/`
When in release mode, the API address will point to whatever the environment variable under `LAERNING_TOOL_API` will be.